### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,18 @@
+name: RuboCop
+on: [pull_request]
+jobs:
+  Rubocop:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Install RuboCop
+      run: gem install rubocop
+    - name: Get RuboCop version
+      run: rubocop -v
+    - name: RuboCop linting
+      run: rubocop
+      

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Tests
+on: [pull_request]
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+        ruby: ['3.3', head]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Install Cucumber and Rspec
+      run: gem install cucumber rspec
+    - name: Get Cucumber version
+      run: cucumber --version
+    - name: Get Rspec version
+      run: rspec -v
+    - name: Run TDD tests
+      run: ruby tdd/tests/hello_test.rb
+    - name: Run BDD tests
+      run: cd bdd && cucumber

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'cucumber'
+gem 'rspec'
+gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,85 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    builder (3.2.4)
+    cucumber (9.1.2)
+      builder (~> 3.2, >= 3.2.4)
+      cucumber-ci-environment (~> 9.2, >= 9.2.0)
+      cucumber-core (~> 12.0)
+      cucumber-cucumber-expressions (~> 17.0)
+      cucumber-gherkin (> 24, < 27)
+      cucumber-html-formatter (> 20.3, < 22)
+      cucumber-messages (> 19, < 25)
+      diff-lcs (~> 1.5)
+      mini_mime (~> 1.1, >= 1.1.5)
+      multi_test (~> 1.1, >= 1.1.0)
+      sys-uname (~> 1.2, >= 1.2.3)
+    cucumber-ci-environment (9.2.0)
+    cucumber-core (12.0.0)
+      cucumber-gherkin (>= 25, < 27)
+      cucumber-messages (>= 20, < 23)
+      cucumber-tag-expressions (~> 5.0, >= 5.0.4)
+    cucumber-cucumber-expressions (17.0.1)
+    cucumber-gherkin (26.2.0)
+      cucumber-messages (>= 19.1.4, < 22.1)
+    cucumber-html-formatter (21.2.0)
+      cucumber-messages (> 19, < 25)
+    cucumber-messages (22.0.0)
+    cucumber-tag-expressions (5.0.6)
+    diff-lcs (1.5.1)
+    ffi (1.16.3)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    mini_mime (1.1.5)
+    multi_test (1.1.0)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
+    rainbow (3.1.1)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.0)
+    rubocop (1.60.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    sys-uname (1.2.3)
+      ffi (~> 1.1)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  ruby
+  x86_64-darwin-23
+
+DEPENDENCIES
+  cucumber
+  rspec
+  rubocop
+
+BUNDLED WITH
+   2.5.4

--- a/README.md
+++ b/README.md
@@ -21,12 +21,9 @@ These are some very basic examples on how TDD and BDD work in Ruby.
 ruby tests/hello_test.rb
 ```
 
-* Watch the test failing
-* Open `hello.rb` and enable the code
-* Run the test again
+The test explicitly does not fail because of the CI tests.
 
 ## Behavior-driven development (BDD)
-
 
 The idea behind BDD is built on top of TDD, with the difference of writing tests as a
 specification of the behavior of a system instead of just testing the code.
@@ -37,7 +34,7 @@ Before you start with Cucumber, you need to initializes the folder structure and
 generate conventional files. This was already done here and you only need it when
 you start a fresh project.
 
-### Executing the test
+### Executing the BDD tests
 
 * Go inside the `bdd` folder
 * Execute the test with
@@ -50,8 +47,3 @@ cucumber
 cucumber features/calculator.feature
 cucumber features/hello.feature
 ```
-
-* Watch the test fail
-* Open the feature and fix the expectations
-* Run the test again
-

--- a/bdd/features/calculator.feature
+++ b/bdd/features/calculator.feature
@@ -6,4 +6,4 @@ Feature: Simple calculator
   Scenario: Add two numbers
     Given I enter 1 and 2 into the calculator
     When I want to add them
-    Then the result should be 4
+    Then the result should be 3

--- a/bdd/features/support/env.rb
+++ b/bdd/features/support/env.rb
@@ -1,0 +1,1 @@
+# frozen_string_literal: true

--- a/tdd/hello.rb
+++ b/tdd/hello.rb
@@ -2,7 +2,7 @@
 
 # Simple HelloWorld class
 class HelloWorld
-  # def greet(name)
-  #   @greetings = "Hello, #{name}!"
-  # end
+  def greet(name)
+    @greetings = "Hello, #{name}!"
+  end
 end


### PR DESCRIPTION
This will add GitHub actions for

- Dependabot GitHub action updates
- RuboCop linting
- BDD / TDD CI tests

Furthermore, it 

- adjusts the tests and the `README`, so they will succeed by default
- adds a `Gemfile` and `Gemfile.lock`